### PR TITLE
Add destroy image functions

### DIFF
--- a/aeacus-src/aeacus.go
+++ b/aeacus-src/aeacus.go
@@ -30,7 +30,6 @@ var teamID string
 var dirPath string
 
 func main() {
-
 	id := imageData{0, 0, 0, []scoreItem{}, 0, []scoreItem{}, 0, 0, []string{"green", "OK", "green", "OK", "green", "OK"}, false}
 
 	if runtime.GOOS == "linux" {
@@ -49,6 +48,7 @@ func main() {
 		Usage:                  "setup and score vulnerabilities in an image",
 		Action: func(c *cli.Context) error {
 			mc := metaConfig{c, teamID, dirPath, scoringChecks{}}
+			timeCheck(&mc)
 			runningPermsCheck()
 			checkConfig(&mc)
 			scoreImage(&mc, &id)
@@ -69,6 +69,7 @@ func main() {
 				Action: func(c *cli.Context) error {
 					runningPermsCheck()
 					mc := metaConfig{c, teamID, dirPath, scoringChecks{}}
+					timeCheck(&mc)
 					checkConfig(&mc)
 					scoreImage(&mc, &id)
 					return nil
@@ -80,6 +81,7 @@ func main() {
 				Usage:   "Check that the scoring config is valid",
 				Action: func(c *cli.Context) error {
 					mc := metaConfig{c, teamID, dirPath, scoringChecks{}}
+					timeCheck(&mc)
 					checkConfig(&mc)
 					return nil
 				},
@@ -90,6 +92,7 @@ func main() {
 				Usage:   "Encrypt scoring.conf to scoring.dat",
 				Action: func(c *cli.Context) error {
 					mc := metaConfig{c, teamID, dirPath, scoringChecks{}}
+					timeCheck(&mc)
 					writeConfig(&mc)
 					return nil
 				},
@@ -100,6 +103,7 @@ func main() {
 				Usage:   "Check that scoring.dat is valid",
 				Action: func(c *cli.Context) error {
 					mc := metaConfig{c, teamID, dirPath, scoringChecks{}}
+					timeCheck(&mc)
 					decryptedData, err := tryDecodeString(readData(&mc))
 					if err != nil {
 						return errors.New("error in reading scoring.dat")
@@ -161,6 +165,7 @@ func main() {
 				Action: func(c *cli.Context) error {
 					runningPermsCheck()
 					mc := metaConfig{c, teamID, dirPath, scoringChecks{}}
+					timeCheck(&mc)
 					releaseImage(&mc)
 					return nil
 				},

--- a/aeacus-src/utility_linux.go
+++ b/aeacus-src/utility_linux.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"time"
 	"unicode/utf8"
 )
 
@@ -108,11 +109,18 @@ func createFQs(mc *metaConfig, numFqs int) {
 	}
 }
 
+func timeCheck(mc *metaConfig) {
+	if time.Now().Unix() >= mc.Config.EndDate {
+		destroyImage(&mc)
+	}
+}
+
 func destroyImage(mc *metaConfig) {
 	failPrint("Destroying the image!")
 	if mc.Cli.Bool("v") {
 		warnPrint("Since you're running this in verbose mode, I assume you're a developer who messed something up. You've been spared from image deletion but please be careful.")
 	} else {
-		// destroying ideas: start a classic rm -rf in the background, delete /etc/passwd, start a rm -rf in foreground for /etc/, then /bin/, then /home/, then kill -9 all processes, then rm -rf foreground everything else
+		shellCommand("rm -rf /opt/aeacus/scoring.dat")
+		os.Exit(1)
 	}
 }

--- a/examples/linux-allchecks.conf
+++ b/examples/linux-allchecks.conf
@@ -5,6 +5,7 @@ user = "sha"
 os = "Ubuntu 20.04"
 remote = "https://127.0.0.1"
 local = "yes"
+enddate = "1595116800"
 
 [[check]]
 [[check.pass]]


### PR DESCRIPTION
Please review this, it's untested. PS, the end date must be a Unix timestamp. Essentially, it just deletes `scoring.dat` after time's up.