### PR TITLE
Start service on startup

### DIFF
--- a/cmd/gui_windows.go
+++ b/cmd/gui_windows.go
@@ -2,8 +2,9 @@ package cmd
 
 func LaunchIDPrompt() {
 	powerShellPrompt := `
+    Start-Service -Name CSSClient -ErrorAction SilentlyContinue
     $teamIDContent = Get-Content C:\aeacus\TeamID.txt
-    if ($teamIDContent -eq "YOUR-TEAMID-HERE") {
+    if ($teamIDContent -match "YOUR-TEAMID-HERE") {
     Add-Type -AssemblyName System.Windows.Forms
     [System.Windows.Forms.Application]::EnableVisualStyles()
 


### PR DESCRIPTION
people having issues where if they open the image like 3 days after it was released the scoring service is stopped even though it's set to automatic. This should fix most issues with that as there is a scheduled task that runs at startup and executes phocus.exe -i yes. Also switched -eq to -match. -eq only passes if the file contains exactly that string and nothing else, whereas -match just checks to see if the regex is satisfied or if the string exists anywhere in the file.