### PR TITLE
Fix dirContainsRegex

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ points = -5 # This check is now a penalty, because it has negative points
 
 ## ReadMe Configuration
 
-Put your README in `ReadMe.conf`. It's pretty self explanatory. Here's a template:
+Put your README in `ReadMe.conf`. It's pretty self-explanatory. Here's a template:
 
 ```
 <!-- Put your comments/additions to the normal ReadMe here! -->

--- a/cmd/checks.go
+++ b/cmd/checks.go
@@ -259,7 +259,7 @@ func dirContainsRegex(dirName, expressionString string) (bool, error) {
 	}
 	for _, file := range files {
 		result, err := fileContainsRegex(file, expressionString)
-		if err != nil {
+		if err != nil && !string.Contains(err.Error(), "The process cannot access the file because it is being used by another process.") {
 			return false, err
 		}
 		if result {

--- a/cmd/checks.go
+++ b/cmd/checks.go
@@ -259,7 +259,7 @@ func dirContainsRegex(dirName, expressionString string) (bool, error) {
 	}
 	for _, file := range files {
 		result, err := fileContainsRegex(file, expressionString)
-		if err != nil && !strings.Contains(err.Error(), "The process cannot access the file because it is being used by another process.") {
+		if os.IsPermission(err) {
 			return false, err
 		}
 		if result {

--- a/cmd/checks.go
+++ b/cmd/checks.go
@@ -259,7 +259,7 @@ func dirContainsRegex(dirName, expressionString string) (bool, error) {
 	}
 	for _, file := range files {
 		result, err := fileContainsRegex(file, expressionString)
-		if err != nil && !string.Contains(err.Error(), "The process cannot access the file because it is being used by another process.") {
+		if err != nil && !strings.Contains(err.Error(), "The process cannot access the file because it is being used by another process.") {
 			return false, err
 		}
 		if result {


### PR DESCRIPTION
To quote my commit message:
"I don't actually know go so it is very possible that I completely messed up the 1/2 line addition. Please make sure I did not.
Long story short the check for dirContainsRegex function when it tried to access a file that was already open in another process. Because the function would terminate upon encountering an error, this means certain files would not be checked. This is very sad. I have made it less sad."