### PR TITLE
Change from x86 to 64 bit

### DIFF
--- a/cmd/release_windows.go
+++ b/cmd/release_windows.go
@@ -2,7 +2,7 @@ package cmd
 
 // WriteDesktopFiles writes default scoring engine files to the desktop
 func WriteDesktopFiles() {
-	firefoxBinary := `C:\Program Files (x86)\Mozilla Firefox\firefox.exe`
+	firefoxBinary := `C:\Program Files\Mozilla Firefox\firefox.exe`
 	infoPrint("Writing ScoringReport.html shortcut to Desktop...")
 	cmdString := `$WshShell = New-Object -comObject WScript.Shell; $Shortcut = $WshShell.CreateShortcut("C:\Users\` + mc.Config.User + `\Desktop\ScoringReport.lnk"); $Shortcut.TargetPath = "` + firefoxBinary + `"; $Shortcut.Arguments = "C:\aeacus\assets\ScoringReport.html"; $Shortcut.Save()`
 	shellCommand(cmdString)


### PR DESCRIPTION
The vast majority of times when I deal with images they are 64 bit and use 64-bit Firefox so this will make it so the desktop shortcuts actually end up working on release because the shortcuts will reference the proper binary.