### PR TITLE
SecurityPolicy & docs

### DIFF
--- a/cmd/checks_windows.go
+++ b/cmd/checks_windows.go
@@ -81,12 +81,18 @@ func processCheck(check *check, checkType, arg1, arg2, arg3 string) bool {
 	*/
 	case "SecurityPolicy":
 		if check.Message == "" {
+			if arg3 != "" {
+				check.Message = "Security policy option " + arg1 + " is between \"" + arg2 + "\" and \"" + arg3 + "\""
+			}
 			check.Message = "Security policy option " + arg1 + " is \"" + arg2 + "\""
 		}
 		result, err := securityPolicy(arg1, arg2, arg3)
 		return err == nil && result
 	case "SecurityPolicyNot":
 		if check.Message == "" {
+			if arg3 != "" {
+				check.Message = "Security policy option " + arg1 + " is not between \"" + arg2 + "\" and \"" + arg3 + "\""
+			}
 			check.Message = "Security policy option " + arg1 + " is not \"" + arg2 + "\""
 		}
 		result, err := securityPolicy(arg1, arg2, arg3)
@@ -424,7 +430,10 @@ func securityPolicy(keyName, keyValue, optValue string) (bool, error) {
 			failPrint(keyValue + " is not a valid integer for SecurityPolicy check")
 			return false, errors.New("Invalid keyValue")
 		}
-		var result1, _ = strconv.Atoi(strings.Split(output, " = ")[1])
+		var result1, e = strconv.Atoi(strings.Split(output, " = ")[1])
+		if e != nil {
+			return false, e
+		}
 		if optValue != "" {
 			intHigh, err := strconv.Atoi(optValue)
 			if err != nil {

--- a/cmd/checks_windows.go
+++ b/cmd/checks_windows.go
@@ -424,15 +424,22 @@ func securityPolicy(keyName, keyValue, optValue string) (bool, error) {
 			failPrint(keyValue + " is not a valid integer for SecurityPolicy check")
 			return false, errors.New("Invalid keyValue")
 		}
-		intHigh, err := strconv.Atoi(optValue)
-		if err != nil {
-			failPrint(optValue + " is not a valid integer for SecurityPolicy check")
-			return false, errors.New("Invalid optValue")
-		}
 		var result1, _ = strconv.Atoi(strings.Split(output, " = ")[1])
-		if intLow < result1 && result1 < intHigh {
-			return true, nil
+		if optValue != "" {
+			intHigh, err := strconv.Atoi(optValue)
+			if err != nil {
+				failPrint(optValue + " is not a valid integer for SecurityPolicy check")
+				return false, errors.New("Invalid optValue")
+			}
+			if intLow <= result1 && result1 <= intHigh {
+				return true, nil
+			}
+		} else {
+			if result1 == intLow {
+				return true, nil
+			}
 		}
+
 	} else {
 		desiredString = keyName + " = " + keyValue
 	}

--- a/cmd/checks_windows.go
+++ b/cmd/checks_windows.go
@@ -83,13 +83,13 @@ func processCheck(check *check, checkType, arg1, arg2, arg3 string) bool {
 		if check.Message == "" {
 			check.Message = "Security policy option " + arg1 + " is \"" + arg2 + "\""
 		}
-		result, err := securityPolicy(arg1, arg2)
+		result, err := securityPolicy(arg1, arg2, arg3)
 		return err == nil && result
 	case "SecurityPolicyNot":
 		if check.Message == "" {
 			check.Message = "Security policy option " + arg1 + " is not \"" + arg2 + "\""
 		}
-		result, err := securityPolicy(arg1, arg2)
+		result, err := securityPolicy(arg1, arg2, arg3)
 		return err == nil && !result
 	case "RegistryKey":
 		if check.Message == "" {
@@ -395,7 +395,7 @@ func startupProgramExists(progName string) (bool, error) {
 	return true, nil
 }
 
-func securityPolicy(keyName, keyValue string) (bool, error) {
+func securityPolicy(keyName, keyValue, optValue string) (bool, error) {
 	var desiredString string
 	if regKey, ok := secpolToKey[keyName]; ok {
 		return registryKey(regKey, keyValue, false)
@@ -407,7 +407,7 @@ func securityPolicy(keyName, keyValue string) (bool, error) {
 	re := regexp.MustCompile("(?m)[\r\n]+^.*" + keyName + ".*$")
 	output := strings.TrimSpace(string(re.Find([]byte(seceditOutput))))
 	if output == "" {
-		return false, errors.New("securitypolicy item not found")
+		return false, errors.New("SecurityPolicy item not found")
 	}
 	if keyName == "NewAdministratorName" || keyName == "NewGuestName" {
 		// These two are strings, not numbers, so they have ""
@@ -415,31 +415,23 @@ func securityPolicy(keyName, keyValue string) (bool, error) {
 	} else if keyName == "MinimumPasswordAge" ||
 		keyName == "MinimumPasswordLength" ||
 		keyName == "LockoutDuration" ||
-		keyName == "ResetLockoutCount" {
+		keyName == "ResetLockoutCount" ||
+		keyName == "MaximumPasswordAge" ||
+		keyName == "LockoutBadCount" {
 		// Fields where the arg should be X or higher (up to 999)
-		intKeyValue, err := strconv.Atoi(keyValue)
+		intLow, err := strconv.Atoi(keyValue)
 		if err != nil {
 			failPrint(keyValue + " is not a valid integer for SecurityPolicy check")
 			return false, errors.New("Invalid keyValue")
 		}
-		for c := intKeyValue; c <= 999; c++ {
-			desiredString = keyName + " = " + strconv.Itoa(c)
-			if output == desiredString {
-				return true, err
-			}
-		}
-	} else if keyName == "MaximumPasswordAge" || keyName == "LockoutBadCount" {
-		// Fields where arg should be X or lower but NOT 0
-		intKeyValue, err := strconv.Atoi(keyValue)
+		intHigh, err := strconv.Atoi(optValue)
 		if err != nil {
-			failPrint(keyValue + " is not a valid integer for SecurityPolicy check")
-			return false, errors.New("Invalid keyValue")
+			failPrint(optValue + " is not a valid integer for SecurityPolicy check")
+			return false, errors.New("Invalid optValue")
 		}
-		for c := intKeyValue; c > 0; c-- {
-			desiredString = keyName + " = " + strconv.Itoa(c)
-			if output == desiredString {
-				return true, nil
-			}
+		var result1, _ = strconv.Atoi(strings.Split(output, " = ")[1])
+		if intLow < result1 && result1 < intHigh {
+			return true, nil
 		}
 	} else {
 		desiredString = keyName + " = " + keyValue

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -269,7 +269,8 @@ arg2='0'
 ```
 
 > **Note**: For all integer-based values (such as `MinimumPasswordAge`), the `optValue` (`arg3`) can be used.
-> `arg2` can be the lower bound, with `arg3` as the higher bound, such as `arg2` < `result` < `arg3`.
+> `arg2` can be the lower bound, with `arg3` as the higher bound, such as `arg2` =< `result` =< `arg3`.\
+> If no `arg3` is provided, then the system will default back to if `result` = `arg2`.
 
 ```
 type='SecurityPolicy'

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -260,7 +260,7 @@ arg1='backdoor.exe'
 
 > (WIP) **StartupProgramExists** checks the startup folder, Run and RunOnce registry keys, and (other startup methods on windows)
 
-**SecurityPolicy**: pass if key is equal to value
+**SecurityPolicy**: pass if key is within the bounds for value
 
 ```
 type='SecurityPolicy'
@@ -268,8 +268,15 @@ arg1='DisableCAD'
 arg2='0'
 ```
 
-> **Note**: If your value should be X or higher (for example, MinimumPasswordAge should be 1 or higher), or if your value should be X or lower (but not 0) (ex. MaximumPasswordAge should be between 1 and 999), the `SecurityPolicy` check will intelligently score it for you.
+> **Note**: For all integer-based values (such as `MinimumPasswordAge`), the `optValue` (`arg3`) can be used.
+> `arg2` can be the lower bound, with `arg3` as the higher bound, such as `arg2` < `result` < `arg3`.
 
+```
+type='SecurityPolicy'
+arg1='MaximumPasswordAge'
+arg2='80'
+arg3='100'
+```
 > Values are checking Registry Keys and `secedit.exe` behind the scenes. This means `0` is `Disabled` and `1` is `Enabled`. [See here for reference](securitypolicy.md).
 
 **RegistryKey**: pass if key is equal to value

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -80,10 +80,10 @@ arg2='403926033d001b5279df37cbbe5287b7c7c267fa'
 
 > **Note!** If a check has negative points assigned to it, it automatically becomes a penalty.
 
-**PackageInstalled**: pass if package is installed
+**ProgramInstalled**: pass if program is installed
 
 ```
-type='PackageInstalled'
+type='ProgramInstalled'
 arg1='Mozilla Firefox 75 (x64 en-US)'
 ```
 


### PR DESCRIPTION
Repairing the `SecurityPolicy` function for Windows with a lower and upper bound for integer-based policies, such as MinimumPasswordAge.