### PR TITLE
Implement version field

### DIFF
--- a/cmd/configs.go
+++ b/cmd/configs.go
@@ -36,6 +36,11 @@ func parseConfig(configContent string) {
 			os.Exit(1)
 		}
 	}
+	
+	// This is probably going to be constantly throwing warnings because we never actually update the version :upside_down:
+	if mc.Config.Version != cmd.AeacusVersion {
+		warnPrint("Scoring version does not match Aeacus version! Compatability issues may occur.")
+	}
 }
 
 // WriteConfig reads the plaintext configuration from sourceFile, and writes
@@ -100,6 +105,7 @@ func printConfig() {
 	fmt.Println("EndDate:", mc.Config.EndDate)
 	fmt.Println("NoDestroy:", mc.Config.NoDestroy)
 	fmt.Println("DisableShell:", mc.Config.DisableShell)
+	fmt.Println("DisableShell:", mc.Config.Version)
 	fmt.Println("Checks:")
 	for i, check := range mc.Config.Check {
 		fmt.Printf("\tCheck %d (%d points):\n", i+1, check.Points)

--- a/cmd/configs.go
+++ b/cmd/configs.go
@@ -96,6 +96,7 @@ func readData() (string, error) {
 // by readData and parseConfig.
 func printConfig() {
 	passPrint("Configuration " + mc.DirPath + ScoringConf + " check passed!")
+	fmt.Println("Aeacus Version:", mc.Config.Version)
 	fmt.Println("Title:", mc.Config.Title)
 	fmt.Println("Name:", mc.Config.Name)
 	fmt.Println("OS:", mc.Config.OS)
@@ -105,7 +106,6 @@ func printConfig() {
 	fmt.Println("EndDate:", mc.Config.EndDate)
 	fmt.Println("NoDestroy:", mc.Config.NoDestroy)
 	fmt.Println("DisableShell:", mc.Config.DisableShell)
-	fmt.Println("DisableShell:", mc.Config.Version)
 	fmt.Println("Checks:")
 	for i, check := range mc.Config.Check {
 		fmt.Printf("\tCheck %d (%d points):\n", i+1, check.Points)

--- a/cmd/structs.go
+++ b/cmd/structs.go
@@ -6,8 +6,8 @@ import (
 
 // metaConfig is the overarching context used by most functions in aeacus.
 type metaConfig struct {
-	TeamID      string
 	DirPath     string
+	TeamID      string
 	Config      scoringChecks
 	Image       imageData
 	Conn        connData
@@ -19,24 +19,24 @@ type metaConfig struct {
 // wiped, removed, etc, on each run without affecting anything else.
 type imageData struct {
 	RunningTime time.Time
+	Contribs    int
+	Detracts    int
 	Score       int
 	ScoredVulns int
-	Points      []scoreItem
-	Contribs    int
-	Penalties   []scoreItem
-	Detracts    int
 	TotalPoints int
+	Penalties   []scoreItem
+	Points      []scoreItem
 }
 
 // connData represents the current connectivity state of the image to the
 // internet and the scoring server.
 type connData struct {
-	ServerColor   string
-	ServerStatus  string
-	NetColor      string
-	NetStatus     string
 	OverallColor  string
 	OverallStatus string
+	NetColor      string
+	NetStatus     string
+	ServerColor   string
+	ServerStatus  string
 }
 
 // scoreItem is the scoring report representation of a check, containing only
@@ -49,16 +49,16 @@ type scoreItem struct {
 // scoringChecks is a representation of the TOML configuration typically
 // specific in scoring.conf.
 type scoringChecks struct {
+	DisableShell bool
 	Local        bool
 	NoDestroy    bool
-	DisableShell bool
+	EndDate      string
 	Name         string
+	OS           string
+	Password     string
+	Remote       string
 	Title        string
 	User         string
-	OS           string
-	Remote       string
-	Password     string
-	EndDate      string
 	Check        []check
 }
 
@@ -68,9 +68,9 @@ type scoringChecks struct {
 type check struct {
 	Message      string
 	Points       int
+	Fail         []condition
 	Pass         []condition
 	PassOverride []condition
-	Fail         []condition
 }
 
 // condition is a single pass/fail condition inside of a check. It supports up

--- a/cmd/structs.go
+++ b/cmd/structs.go
@@ -59,6 +59,7 @@ type scoringChecks struct {
 	Remote       string
 	Title        string
 	User         string
+	Version      string
 	Check        []check
 }
 

--- a/cmd/utility.go
+++ b/cmd/utility.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	AeacusVersion = "1.6.0"
+	AeacusVersion = "1.7.3"
 	ScoringConf   = "scoring.conf"
 	ScoringData   = "scoring.dat"
 	LinuxDir      = "/opt/aeacus/"

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -60,7 +60,7 @@ enddate = "2004/06/05 13:09:00 PDT"
 nodestroy = true
 ```
 
-**disableshell**: Enables remote shell functionality. If set to true, aeacus will not attempt to connect to the remote shell.
+**disableshell**: **WARNING: this does not currently work.** Enables remote shell functionality. If set to true, aeacus will not attempt to connect to the remote shell.
 
 ```
 disableshell = false

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -1,0 +1,73 @@
+# aeacus
+
+## Fields
+
+This is a list of configuration fields that are required when creating `aeacus`. Well, most of them are required.
+
+**name**: Image name, primarily used to organize remote scoring.
+
+> **Note!** This field is not mandatory if you use local scoring.
+
+```
+name = "ubuntu-18-dabbingdabbers"
+```
+
+**title**: Round title, as seen in the scoring report and README.
+
+```
+title = "CyberPatio Practice Round 18"
+```
+
+**os**: Name of the operating system, as seen in the README.
+
+```
+os = "TempleOS 5.03"
+```
+
+**user**: Main user of the image.
+
+```
+user = "sysadmin"
+```
+
+**remote**: Address of remote server for scoring. If remote scoring is enabled, aeacus will refuse to score the image unless a connection to the server can be established.
+
+```
+remote = "8.8.8.8"
+```
+
+**password**: Password used for encrypting remote reporting traffic.
+
+```
+password = "H4!b5at+kWls-8yh4Guq"
+```
+
+**local**: Enables (technically, disables) remote scoring. If no remote address is specified, this will automatically be set to true.
+
+```
+local = true
+```
+
+**enddate**: Defines self-destruct date. If the engine is run after this date, the image will self destruct. Formatted as YEAR/MO/DA HR:MN:SC ZONE
+
+```
+enddate = "2004/06/05 13:09:00 PDT"
+```
+
+**nodestroy**: Governs self-destruct behavior. If this is set to true, only the aeacus folder will be deleted, leaving the rest of the image intact.
+
+```
+nodestroy = true
+```
+
+**disableshell**: Enables remote shell functionality. If set to true, aeacus will not attempt to connect to the remote shell.
+
+```
+disableshell = false
+```
+
+**version**: Version of aeacus that the configuration was built for. Primarily used for compatibility checks, the engine will throw a warning if the binary version does not match the version specified in this field. In the future, this may also be used for backwards compatibility functionality.
+
+```
+version = "1.6.0"
+```

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -42,7 +42,7 @@ remote = "8.8.8.8"
 password = "H4!b5at+kWls-8yh4Guq"
 ```
 
-**local**: Enables (technically, disables) remote scoring. If no remote address is specified, this will automatically be set to true.
+**local**: Disables remote scoring. If no remote address is specified, this will automatically be set to true.
 
 ```
 local = true


### PR DESCRIPTION
Hello to all the very attractive and wonderful maintainers,

As I'm sure you're aware, people have actually started working on the engine recently. While these new updates and changes are widely regarded as a Very Good Thing, some of the more outdated image creators are running into issues with nonexistent checks and other small issues.

To make these issues easier to diagnose, I've added a `version` field to the scoring data. If a discrepancy is detected between this version and the binary version, the engine will throw a warning. In the future, this could also be used to implement a basic form of backwards compatibility, although I'm of the firm belief that accommodating for old curmudgeonly people who refuse to let go of the past is bad practice. Still, the possibility is nice to consider.

I also did a bit of cleaning up. Our structs are now mostly alphabetically organized. Please make sure that this doesn't somehow break the entire engine. Documentation for the configuration fields has been added, but is severely lacking. I would appreciate if someone who is more familiar with the configuration format could update for these changes.

I vaguely recall a build error happening when I first wrote this code. Someone should probably look into that.