### PR TITLE
Auto-trusting of .desktop files for Linux release

### DIFF
--- a/cmd/release_linux.go
+++ b/cmd/release_linux.go
@@ -11,6 +11,7 @@ func WriteDesktopFiles() {
 	shellCommand("cp " + mc.DirPath + "misc/desktop/*.desktop /home/" + mc.Config.User + "/Desktop/")
 	shellCommand("chmod +x /home/" + mc.Config.User + "/Desktop/*.desktop")
 	shellCommand("chown " + mc.Config.User + ":" + mc.Config.User + " /home/" + mc.Config.User + "/Desktop/*")
+	shellCommand("for i in /home/" + mc.Config.User + "/Desktop/*.desktop; do gio set \"$i\" \"metadata::trusted\" yes ;done")
 }
 
 // ConfigureAutologin configures the auto-login capability for LightDM and


### PR DESCRIPTION
This is currently not working on Ubuntu 20.04 but it is on 18.04...