### PR TITLE
FileOwner check no longer relies on PowerShell.

### DIFF
--- a/checks_windows.go
+++ b/checks_windows.go
@@ -28,8 +28,7 @@ func (c cond) BitlockerEnabled() (bool, error) {
 
 func (c cond) FileOwner() (bool, error) {
 	c.requireArgs("Path", "Name")
-	owner, err := shellCommandOutput("(Get-Acl " + c.Path + ").Owner")
-	owner = strings.TrimSpace(owner)
+	owner, err := getFileOwner(c.Path)
 	return owner == c.Name, err
 }
 

--- a/utility_windows.go
+++ b/utility_windows.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"os/user"
 	"strings"
 	"unsafe"
 
@@ -266,11 +265,11 @@ func getFileOwner(path string) (string, error) {
 		nil); err != nil {
 		return "", errors.Wrapf(err, "acl: failed to get security info for '%s' ", path)
 	}
-	var ownerUser, err = user.LookupId(sid.String())
+	var ownerAccount, _, _, err = sid.LookupAccount("")
 	if err != nil {
-		return "", errors.Wrapf(err, "Failed to find user for SID '%s'", sid.String())
+		return "", errors.Wrapf(err, "Failed to find account for SID '%s'", sid.String())
 	}
-	return ownerUser.Username, nil
+	return ownerAccount, nil
 }
 
 func getFileRights(filePath, username string) (map[string]string, error) {


### PR DESCRIPTION
Documentation has not been updated yet as there are things to be decided:

Currently, `FileOwner` check requires `c.Path` and `c.Name`. Would it be better to use `c.User` instead?

Also, the PowerShell-less `FileOwner` by default returns `MachineName\USERNAME`. Should we parse out `MachineName`, or leave it in?
Parsing it out will ensure backwards compatibility (hopefully), but could limit future scoring options (as we could score with AD and see if the user is domain or local).