### PR TITLE
refactor: don't encrypt the update string if a password is not set

### DIFF
--- a/configs.go
+++ b/configs.go
@@ -44,6 +44,16 @@ func parseConfig(configContent string) {
 			fail("Need image name in config if remote is enabled.")
 			os.Exit(1)
 		}
+
+		if conf.Password == "" && conf.DisableRemoteEncryption == false {
+			fail("Need password in config if remote is enabled.")
+			os.Exit(1)
+		}
+
+		if conf.DisableRemoteEncryption && conf.Password != "" {
+			warn("Remote encryption is disabled, but a password is still defined!")
+		}
+
 	}
 
 	// Check if the config version matches ours.

--- a/configs.go
+++ b/configs.go
@@ -31,9 +31,11 @@ func parseConfig(configContent string) {
 	// If there's no remote, local must be enabled.
 	if conf.Remote == "" {
 		conf.Local = true
-	}
-
-	if conf.Remote != "" {
+		if conf.DisableRemoteEncryption {
+			fail("Remote encryption cannot be disabled if remote is not enabled!")
+			os.Exit(1)
+		}
+	} else {
 		if conf.Remote[len(conf.Remote)-1] == '/' {
 			fail("Your remote URL must not end with a slash: try", conf.Remote[:len(conf.Remote)-1])
 			os.Exit(1)
@@ -133,6 +135,11 @@ func printConfig() {
 	}
 	if conf.Remote != "" {
 		pass("Remote:", conf.Remote)
+	}
+	if conf.DisableRemoteEncryption {
+		pass("Remote Encryption:", "Disabled")
+	} else {
+		pass("Remote Encryption:", "Enabled")
 	}
 	if conf.Local {
 		pass("Local:", conf.Local)

--- a/docs/config.md
+++ b/docs/config.md
@@ -44,6 +44,12 @@ remote = "http://scoring.example.com"
 password = "H4!b5at+kWls-8yh4Guq"
 ```
 
+**DisableRemoteEncryption**: Disables encryption of remote reporting traffic. This is not recommended, but can be useful for debugging or if you are using a custom remote endpoint that does not support encryption.
+
+```
+DisableRemoteEncryption = true
+```
+
 **local**: Enables local scoring. If no remote address is specified, this will automatically be set to true.
 
 ```

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -22,6 +22,6 @@ Firewall has been activated - 5 pts
 
 Each newline in the text above actually represents a delimiter, which is a sequence of two bytes (0xff followed by 0xde). This was randomly chosen and serves to separate information from one another in the config update more reliably than a newline.
 
-The report is encrypted with the configuration password, and hex encoded, before being sent to the remote.
+The report is encrypted with the configuration password and hex encoded (unless `DisableRemoteEncryption` is set to `true`), before being sent to the remote.
 
 The function `genUpdate()` creates the report while `reportScore()` sends it.

--- a/remote.go
+++ b/remote.go
@@ -70,7 +70,15 @@ func genUpdate() (string, error) {
 		fail(err)
 		return "", err
 	}
-	finishedUpdate := hexEncode(encryptString(conf.Password, update.String()))
+
+	// If no password has been specified in the configuration (i.e. is empty), don't encrypt the update.
+	finishedUpdate := ""
+	if conf.Password == "" {
+		finishedUpdate = hexEncode(update.String())
+	} else {
+		finishedUpdate = hexEncode(encryptString(conf.Password, update.String()))
+	}
+
 	if err := obfuscateData(&conf.Password); err != nil {
 		fail(err)
 		return "", err

--- a/remote.go
+++ b/remote.go
@@ -71,9 +71,10 @@ func genUpdate() (string, error) {
 		return "", err
 	}
 
-	// If no password has been specified in the configuration (i.e. is empty), don't encrypt the update.
 	finishedUpdate := ""
-	if conf.Password == "" {
+
+	// If DisableRemoteEncryption has been set to true in the configuration, don't encrypt the update.
+	if conf.DisableRemoteEncryption {
 		finishedUpdate = hexEncode(update.String())
 	} else {
 		finishedUpdate = hexEncode(encryptString(conf.Password, update.String()))

--- a/score.go
+++ b/score.go
@@ -63,17 +63,18 @@ type hintItem struct {
 // config is a representation of the TOML configuration typically
 // specific in scoring.conf.
 type config struct {
-	Local    bool
-	Shell    bool
-	EndDate  string
-	Name     string
-	OS       string
-	Password string
-	Remote   string
-	Title    string
-	User     string
-	Version  string
-	Check    []check
+	DisableRemoteEncryption bool
+	Local                   bool
+	Shell                   bool
+	EndDate                 string
+	Name                    string
+	OS                      string
+	Password                string
+	Remote                  string
+	Title                   string
+	User                    string
+	Version                 string
+	Check                   []check
 }
 
 // statusRes is to parse a JSON response from the remote server.


### PR DESCRIPTION
If `DisableRemoteEncryption` has been set to `true` in the configuration file, don't encrypt the scoring update.