### PR TITLE
Add Defender Exclusions for aeacus

### DIFF
--- a/release_windows.go
+++ b/release_windows.go
@@ -129,6 +129,13 @@ func installService() {
 	`
 	shellCommand(idTaskCreate)
 	shellCommand(serviceTaskCreate)
+
+	addExclusions := `
+	Add-MpPreference -ExclusionPath "C:\aeacus\phocus.exe"
+ 	Add-MpPreference -ExclusionPath "C:\aeacus\"
+  	`
+	shellCommand(addExclusions)
+ 
 }
 
 // cleanUp clears out sensitive files left behind by image developers or the


### PR DESCRIPTION
Ensure that Windows Defender doesn't try to quarantine aeacus (the folder and phocus specifically)